### PR TITLE
Add `decodeArray2` with separate decoders for keys and values

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "1.1.0",
     "summary": "Dict with arbitrary ordering (like List)",
     "repository": "https://github.com/Gizra/elm-dictlist.git",
     "license": "MIT",

--- a/src/DictList.elm
+++ b/src/DictList.elm
@@ -58,6 +58,7 @@ module DictList
         , decodeWithKeys
         , decodeKeysAndValues
         , decodeArray
+        , decodeArray2
           -- Conversion
         , toDict
         , fromDict
@@ -122,7 +123,7 @@ between an association list and a `DictList` via `toList` and `fromList`.
 
 # JSON
 
-@docs decodeObject, decodeArray, decodeWithKeys, decodeKeysAndValues
+@docs decodeObject, decodeArray, decodeArray2, decodeWithKeys, decodeKeysAndValues
 
 -}
 
@@ -224,6 +225,17 @@ decodeArray keyMapper valueDecoder =
     Json.Decode.map
         (List.map (\value -> ( keyMapper value, value )) >> fromList)
         (Json.Decode.list valueDecoder)
+
+
+{-| Decodes a JSON array into the DictList. You supply two decoders. Given an element
+of your JSON array, the first decoder should decode the key, and the second decoder
+should decode the value.
+-}
+decodeArray2 : Decoder comparable -> Decoder value -> Decoder (DictList comparable value)
+decodeArray2 keyDecoder valueDecoder =
+    Json.Decode.map2 (,) keyDecoder valueDecoder
+        |> Json.Decode.list
+        |> Json.Decode.map fromList
 
 
 


### PR DESCRIPTION
For the existing `decodeArray`, you provide a single decoder which, given an element of the JSON array, decodes your value. You also provide a regular function to turn your value into a key.

This works fine if your key is stored in your value -- for instance, if you have something like this:

```elm
type alias Contact =
    { id : Int
    , name : String
    , address : String
    }

type alias ContactList =
    DictList Int Contact

decodeContactList : Decoder ContactList
decodeContactList =
    decodeArray .id decodeContact
```

But, because we produce the keys with a regular Elm function, `decodeArray` can only get the key if it can be derived from the value in some way. What if you don't want to do that? What if you'd prefer to not have the key in the value itself? Like this ...

```elm
type alias Contact =
    { name : String
    , address : String
    }

type alias ContactList =
    DictList Int Contact

decodeContactList : Decoder ContactList
decodeContactList =
    decodeArray2 (field "id" int) decodeContact
```

So, that's what this PR supplies -- a `decodeArray2` variant, where you provide two decoders -- one decodes the key, and the other decodes the value. They both get run on each element of the JSON array, and the results are combined in the resulting DictList.


