### PR TITLE
Correct behaviour in `AllDictList` when `==` and the comparator function are inconsistent

### DIFF
--- a/src/AllDictList.elm
+++ b/src/AllDictList.elm
@@ -804,11 +804,18 @@ eq first second =
     (toList first) == (toList second)
 
 
-{-| Element equality and checks referential equality of the ord functions.
+{-| Element equality, according to the ord functions.
 -}
 fullEq : AllDictList k v comparable -> AllDictList k v comparable -> Bool
 fullEq first second =
-    (toList first == toList second) && (getOrd first == getOrd second)
+    let
+        firstWithOrd =
+            List.map (Tuple.mapFirst (getOrd first)) (toList first)
+
+        secondWithOrd =
+            List.map (Tuple.mapFirst (getOrd second)) (toList second)
+    in
+        firstWithOrd == secondWithOrd
 
 
 {-| Get the ord function used by the dictionary.

--- a/src/AllDictList.elm
+++ b/src/AllDictList.elm
@@ -594,7 +594,16 @@ order maintained by the dictionary?
 -}
 indexOfKey : k -> AllDictList k v comparable -> Maybe Int
 indexOfKey key (AllDictList dict list) =
-    List.Extra.elemIndex key list
+    -- Can't just use `elemIndex` because that relies on `==`, which may be
+    -- unreliable ... need to use the `ord`.
+    let
+        ord =
+            AllDict.getOrd dict
+
+        target =
+            ord key
+    in
+        List.Extra.findIndex (\k -> ord k == target) list
 
 
 {-| Given a key, get the key and value at the next position.
@@ -670,29 +679,34 @@ insertAfter afterKey key value (AllDictList dict list) =
         newDict =
             AllDict.insert key value dict
 
-        newList =
-            if afterKey == key then
-                -- If we want to insert it after itself, we can short-circuit
-                list
-            else
-                let
-                    listWithoutKey =
-                        if AllDict.member key dict then
-                            List.Extra.remove key list
-                        else
-                            -- If the key wasn't present, we can skip the removal
-                            list
-                in
-                    case List.Extra.elemIndex afterKey listWithoutKey of
-                        Just index ->
-                            -- We found the existing element, so take apart the list
-                            -- and put it back together
-                            List.take (index + 1) listWithoutKey
-                                ++ (key :: List.drop (index + 1) listWithoutKey)
+        ord =
+            AllDict.getOrd dict
 
-                        Nothing ->
-                            -- The afterKey wasn't found, so we insert the key at the end
-                            listWithoutKey ++ [ key ]
+        afterKeyComparable =
+            ord afterKey
+
+        keyComparable =
+            ord key
+
+        newList =
+            let
+                listWithoutKey =
+                    if AllDict.member key dict then
+                        List.filter (\k -> ord k /= keyComparable) list
+                    else
+                        -- If the key wasn't present, we can skip the removal
+                        list
+            in
+                case List.Extra.findIndex (\k -> ord k == afterKeyComparable) listWithoutKey of
+                    Just index ->
+                        -- We found the existing element, so take apart the list
+                        -- and put it back together
+                        List.take (index + 1) listWithoutKey
+                            ++ (key :: List.drop (index + 1) listWithoutKey)
+
+                    Nothing ->
+                        -- The afterKey wasn't found, so we insert the key at the end
+                        listWithoutKey ++ [ key ]
     in
         AllDictList newDict newList
 
@@ -709,29 +723,34 @@ insertBefore beforeKey key value (AllDictList dict list) =
         newDict =
             AllDict.insert key value dict
 
-        newList =
-            if beforeKey == key then
-                -- If we want to insert it before itself, we can short-circuit
-                list
-            else
-                let
-                    listWithoutKey =
-                        if AllDict.member key dict then
-                            List.Extra.remove key list
-                        else
-                            -- If the key wasn't present, we can skip the removal
-                            list
-                in
-                    case List.Extra.elemIndex beforeKey listWithoutKey of
-                        Just index ->
-                            -- We found the existing element, so take apart the list
-                            -- and put it back together
-                            List.take index listWithoutKey
-                                ++ (key :: List.drop index listWithoutKey)
+        ord =
+            AllDict.getOrd dict
 
-                        Nothing ->
-                            -- The beforeKey wasn't found, so we insert the key at the beginning
-                            key :: listWithoutKey
+        beforeKeyComparable =
+            ord beforeKey
+
+        keyComparable =
+            ord key
+
+        newList =
+            let
+                listWithoutKey =
+                    if AllDict.member key dict then
+                        List.filter (\k -> ord k /= keyComparable) list
+                    else
+                        -- If the key wasn't present, we can skip the removal
+                        list
+            in
+                case List.Extra.findIndex (\k -> ord k == beforeKeyComparable) listWithoutKey of
+                    Just index ->
+                        -- We found the existing element, so take apart the list
+                        -- and put it back together
+                        List.take index listWithoutKey
+                            ++ (key :: List.drop index listWithoutKey)
+
+                    Nothing ->
+                        -- The beforeKey wasn't found, so we insert the key at the beginning
+                        key :: listWithoutKey
     in
         AllDictList newDict newList
 
@@ -882,19 +901,24 @@ insert key value (AllDictList dict list) =
 no changes are made.
 -}
 remove : k -> AllDictList k v comparable -> AllDictList k v comparable
-remove key dictList =
-    case dictList of
-        AllDictList dict list ->
-            if AllDict.member key dict then
-                -- Lists are not particularly optimized for removals ...
-                -- if that becomes a practical issue, we could perhaps
-                -- use an `Array` instead.
-                AllDictList
-                    (AllDict.remove key dict)
-                    (List.Extra.remove key list)
-            else
-                -- We avoid the list removal efficiently in this branch.
-                dictList
+remove key ((AllDictList dict list) as dictList) =
+    if AllDict.member key dict then
+        -- Lists are not particularly optimized for removals ...
+        -- if that becomes a practical issue, we could perhaps
+        -- use an `Array` instead.
+        let
+            ord =
+                AllDict.getOrd dict
+
+            keyComparable =
+                ord key
+        in
+            AllDictList
+                (AllDict.remove key dict)
+                (List.filter (\k -> ord k /= keyComparable) list)
+    else
+        -- We avoid the list removal efficiently in this branch.
+        dictList
 
 
 {-| Update the value for a specific key with a given function. Maintains

--- a/tests/AllDictListTests.elm
+++ b/tests/AllDictListTests.elm
@@ -1,12 +1,13 @@
 module AllDictListTests exposing (..)
 
-import Test exposing (Test, describe, test, fuzz, fuzz2)
-import Fuzz exposing (Fuzzer, intRange)
-import Expect
-import Json.Encode exposing (Value)
-import Dict
+import AllDict
 import AllDictList exposing (..)
+import Dict
+import Expect
+import Fuzz exposing (Fuzzer, intRange)
+import Json.Encode exposing (Value)
 import Set
+import Test exposing (Test, describe, fuzz, fuzz2, test)
 
 
 type Action
@@ -20,6 +21,24 @@ ord action =
     case action of
         Run ->
             2
+
+        Hide ->
+            1
+
+        StandStill ->
+            0
+
+
+{-| You wouldn't expect to get an `ord` function like this, but it's actually quite
+legitimate. It's what you would need for types that don't have a reliable `==` ...
+that is, for types where distinct internal representations ought to be considered
+equal ... which is perfectly legitimate.
+-}
+ordWithUnreliableEquality : Action -> Int
+ordWithUnreliableEquality action =
+    case action of
+        Run ->
+            1
 
         Hide ->
             1
@@ -43,3 +62,120 @@ basicTest =
         \_ ->
             AllDictList.get Run actionDict
                 |> Expect.equal (Just "Run away!")
+
+
+thing : String
+thing =
+    "thing"
+
+
+insertBeforeTest : Test
+insertBeforeTest =
+    describe "insertBefore with custom comparator"
+        [ describe "with reliable equality"
+            [ test "when empty" <|
+                \_ ->
+                    AllDictList.empty ord
+                        |> AllDictList.insertBefore Run Hide thing
+                        |> Expect.all
+                            [ AllDictList.values >> List.length >> Expect.equal 1
+                            , AllDictList.toAllDict >> AllDict.size >> Expect.equal 1
+                            , AllDictList.keys >> Expect.equal [ Hide ]
+                            ]
+            , test "when inserting before existing key" <|
+                \_ ->
+                    AllDictList.empty ord
+                        |> AllDictList.cons Run thing
+                        |> AllDictList.insertBefore Run StandStill thing
+                        |> Expect.all
+                            [ AllDictList.values >> List.length >> Expect.equal 2
+                            , AllDictList.toAllDict >> AllDict.size >> Expect.equal 2
+                            , AllDictList.keys >> Expect.equal [ StandStill, Run ]
+                            ]
+            , test "when inserting before non-existing key" <|
+                \_ ->
+                    AllDictList.empty ord
+                        |> AllDictList.cons Run thing
+                        |> AllDictList.insertBefore Hide StandStill thing
+                        |> Expect.all
+                            [ AllDictList.values >> List.length >> Expect.equal 2
+                            , AllDictList.toAllDict >> AllDict.size >> Expect.equal 2
+                            , AllDictList.keys >> Expect.equal [ StandStill, Run ]
+                            ]
+            , test "when replacing before existing key" <|
+                \_ ->
+                    AllDictList.empty ord
+                        |> AllDictList.cons Hide thing
+                        |> AllDictList.cons Run thing
+                        |> AllDictList.insertBefore Run Hide thing
+                        |> Expect.all
+                            [ AllDictList.values >> List.length >> Expect.equal 2
+                            , AllDictList.toAllDict >> AllDict.size >> Expect.equal 2
+                            , AllDictList.keys >> Expect.equal [ Hide, Run ]
+                            ]
+            , test "when replacing before non-existing key" <|
+                \_ ->
+                    AllDictList.empty ord
+                        |> AllDictList.cons Hide thing
+                        |> AllDictList.cons Run thing
+                        |> AllDictList.insertBefore StandStill Hide thing
+                        |> Expect.all
+                            [ AllDictList.values >> List.length >> Expect.equal 2
+                            , AllDictList.toAllDict >> AllDict.size >> Expect.equal 2
+                            , AllDictList.keys >> Expect.equal [ Hide, Run ]
+                            ]
+            ]
+        , describe "with unreliable equality"
+            [ test "when empty" <|
+                \_ ->
+                    AllDictList.empty ordWithUnreliableEquality
+                        |> AllDictList.insertBefore Run Hide thing
+                        |> Expect.all
+                            [ AllDictList.values >> List.length >> Expect.equal 1
+                            , AllDictList.toAllDict >> AllDict.size >> Expect.equal 1
+                            , AllDictList.keys >> Expect.equal [ Hide ]
+                            ]
+            , test "when inserting before existing key" <|
+                \_ ->
+                    AllDictList.empty ordWithUnreliableEquality
+                        |> AllDictList.cons Run thing
+                        |> AllDictList.insertBefore Run StandStill thing
+                        |> Expect.all
+                            [ AllDictList.values >> List.length >> Expect.equal 2
+                            , AllDictList.toAllDict >> AllDict.size >> Expect.equal 2
+                            , AllDictList.keys >> Expect.equal [ StandStill, Run ]
+                            ]
+            , test "when inserting before non-existing key" <|
+                \_ ->
+                    AllDictList.empty ordWithUnreliableEquality
+                        |> AllDictList.cons Run thing
+                        |> AllDictList.insertBefore Hide StandStill thing
+                        |> Expect.all
+                            [ AllDictList.values >> List.length >> Expect.equal 2
+                            , AllDictList.toAllDict >> AllDict.size >> Expect.equal 2
+                            , AllDictList.keys >> Expect.equal [ StandStill, Run ]
+                            ]
+            , test "when replacing before existing key" <|
+                \_ ->
+                    AllDictList.empty ordWithUnreliableEquality
+                        |> AllDictList.cons Hide thing
+                        |> AllDictList.cons Run thing
+                        |> AllDictList.insertBefore Run Hide thing
+                        |> Expect.all
+                            [ AllDictList.values >> List.length >> Expect.equal 2
+                            , AllDictList.toAllDict >> AllDict.size >> Expect.equal 2
+                            , AllDictList.keys >> Expect.equal [ Hide, Run ]
+                            ]
+            , test "when replacing before non-existing key" <|
+                \_ ->
+                    AllDictList.empty ordWithUnreliableEquality
+                        |> AllDictList.cons Hide thing
+                        |> AllDictList.cons Run thing
+                        |> AllDictList.insertBefore StandStill Hide thing
+                        |> Expect.all
+                            [ AllDictList.values >> List.length >> Expect.equal 2
+                            , AllDictList.toAllDict >> AllDict.size >> Expect.equal 2
+                            , AllDictList.keys >> Expect.equal [ Hide, Run ]
+                            ]
+            ]
+        ]

--- a/tests/AllDictListTests.elm
+++ b/tests/AllDictListTests.elm
@@ -159,23 +159,22 @@ insertBeforeTest =
                 \_ ->
                     AllDictList.empty ordWithUnreliableEquality
                         |> AllDictList.cons Hide thing
-                        |> AllDictList.cons Run thing
-                        |> AllDictList.insertBefore Run Hide thing
+                        |> AllDictList.cons StandStill thing
+                        |> AllDictList.insertBefore StandStill Hide thing
                         |> Expect.all
                             [ AllDictList.values >> List.length >> Expect.equal 2
                             , AllDictList.toAllDict >> AllDict.size >> Expect.equal 2
-                            , AllDictList.keys >> Expect.equal [ Hide, Run ]
+                            , AllDictList.keys >> Expect.equal [ Hide, StandStill ]
                             ]
             , test "when replacing before non-existing key" <|
                 \_ ->
                     AllDictList.empty ordWithUnreliableEquality
                         |> AllDictList.cons Hide thing
-                        |> AllDictList.cons Run thing
-                        |> AllDictList.insertBefore StandStill Hide thing
+                        |> AllDictList.insertBefore StandStill StandStill thing
                         |> Expect.all
                             [ AllDictList.values >> List.length >> Expect.equal 2
                             , AllDictList.toAllDict >> AllDict.size >> Expect.equal 2
-                            , AllDictList.keys >> Expect.equal [ Hide, Run ]
+                            , AllDictList.keys >> Expect.equal [ StandStill, Hide ]
                             ]
             ]
         ]

--- a/tests/DictListTests.elm
+++ b/tests/DictListTests.elm
@@ -885,6 +885,7 @@ insertBeforeTest =
                     DictList.insertBefore 0 2 thing DictList.empty
                         |> Expect.all
                             [ DictList.values >> List.length >> Expect.equal 1
+                            , DictList.toDict >> Dict.size >> Expect.equal 1
                             , DictList.keys >> Expect.equal [ 2 ]
                             ]
             , test "when inserting before existing key" <|
@@ -893,6 +894,7 @@ insertBeforeTest =
                         |> DictList.insertBefore 0 2 thing
                         |> Expect.all
                             [ DictList.values >> List.length >> Expect.equal 2
+                            , DictList.toDict >> Dict.size >> Expect.equal 2
                             , DictList.keys >> Expect.equal [ 2, 0 ]
                             ]
             , test "when inserting before non-existing key" <|
@@ -901,6 +903,7 @@ insertBeforeTest =
                         |> DictList.insertBefore 7 2 thing
                         |> Expect.all
                             [ DictList.values >> List.length >> Expect.equal 2
+                            , DictList.toDict >> Dict.size >> Expect.equal 2
                             , DictList.keys >> Expect.equal [ 2, 0 ]
                             ]
             , test "when replacing before existing key" <|
@@ -910,6 +913,7 @@ insertBeforeTest =
                         |> DictList.insertBefore 0 1 thing
                         |> Expect.all
                             [ DictList.values >> List.length >> Expect.equal 2
+                            , DictList.toDict >> Dict.size >> Expect.equal 2
                             , DictList.keys >> Expect.equal [ 1, 0 ]
                             ]
             , test "when replacing before non-existing key" <|
@@ -919,6 +923,7 @@ insertBeforeTest =
                         |> DictList.insertBefore 8 1 thing
                         |> Expect.all
                             [ DictList.values >> List.length >> Expect.equal 2
+                            , DictList.toDict >> Dict.size >> Expect.equal 2
                             , DictList.keys >> Expect.equal [ 1, 0 ]
                             ]
             ]

--- a/tests/DictListTests.elm
+++ b/tests/DictListTests.elm
@@ -5,6 +5,7 @@ things not necessarily tested by the `DictTests` or the `ListTests`.
 -}
 
 import Arithmetic exposing (isEven)
+import Date exposing (Date)
 import Dict
 import DictList exposing (DictList)
 import Expect
@@ -808,6 +809,19 @@ insertAfterTest =
         ]
 
 
+type alias Things =
+    DictList Int Thing
+
+
+type alias Thing =
+    { a : Int
+    , b : Int
+    , c : Float
+    , d : Int
+    , e : Date
+    }
+
+
 insertBeforeTest : Test
 insertBeforeTest =
     describe "insertBefore"
@@ -859,6 +873,55 @@ insertBeforeTest =
                             , pair3
                             ]
                         )
+
+        -- From https://github.com/Gizra/elm-dictlist/issues/16
+        , describe "with record value" <|
+            let
+                thing =
+                    Thing 0 0 0 0 (Date.fromTime 0)
+            in
+            [ test "when empty" <|
+                \_ ->
+                    DictList.insertBefore 0 2 thing DictList.empty
+                        |> Expect.all
+                            [ DictList.values >> List.length >> Expect.equal 1
+                            , DictList.keys >> Expect.equal [ 2 ]
+                            ]
+            , test "when inserting before existing key" <|
+                \_ ->
+                    DictList.cons 0 thing DictList.empty
+                        |> DictList.insertBefore 0 2 thing
+                        |> Expect.all
+                            [ DictList.values >> List.length >> Expect.equal 2
+                            , DictList.keys >> Expect.equal [ 2, 0 ]
+                            ]
+            , test "when inserting before non-existing key" <|
+                \_ ->
+                    DictList.cons 0 thing DictList.empty
+                        |> DictList.insertBefore 7 2 thing
+                        |> Expect.all
+                            [ DictList.values >> List.length >> Expect.equal 2
+                            , DictList.keys >> Expect.equal [ 2, 0 ]
+                            ]
+            , test "when replacing before existing key" <|
+                \_ ->
+                    DictList.cons 1 thing DictList.empty
+                        |> DictList.cons 0 thing
+                        |> DictList.insertBefore 0 1 thing
+                        |> Expect.all
+                            [ DictList.values >> List.length >> Expect.equal 2
+                            , DictList.keys >> Expect.equal [ 1, 0 ]
+                            ]
+            , test "when replacing before non-existing key" <|
+                \_ ->
+                    DictList.cons 1 thing DictList.empty
+                        |> DictList.cons 0 thing
+                        |> DictList.insertBefore 8 1 thing
+                        |> Expect.all
+                            [ DictList.values >> List.length >> Expect.equal 2
+                            , DictList.keys >> Expect.equal [ 1, 0 ]
+                            ]
+            ]
         ]
 
 

--- a/tests/DictListTests.elm
+++ b/tests/DictListTests.elm
@@ -55,13 +55,13 @@ jsonObjectAndExpectedResult =
                             , DictList.cons (toString key) value expected
                             )
                 in
-                    list
-                        |> List.foldr go ( [], DictList.empty )
-                        |> (\( json, expected ) ->
-                                ( "{" ++ String.join ", " json ++ "}"
-                                , expected
-                                )
-                           )
+                list
+                    |> List.foldr go ( [], DictList.empty )
+                    |> (\( json, expected ) ->
+                            ( "{" ++ String.join ", " json ++ "}"
+                            , expected
+                            )
+                       )
             )
 
 
@@ -82,13 +82,13 @@ jsonArrayAndExpectedResult =
                             , DictList.cons key (ValueWithId key value) expected
                             )
                 in
-                    list
-                        |> List.foldr go ( [], DictList.empty )
-                        |> (\( json, expected ) ->
-                                ( "[" ++ String.join ", " json ++ "]"
-                                , expected
-                                )
-                           )
+                list
+                    |> List.foldr go ( [], DictList.empty )
+                    |> (\( json, expected ) ->
+                            ( "[" ++ String.join ", " json ++ "]"
+                            , expected
+                            )
+                       )
             )
 
 
@@ -134,13 +134,13 @@ jsonArray2AndExpectedResult =
                             , DictList.cons key (ValueWithoutId value) expected
                             )
                 in
-                    list
-                        |> List.foldr go ( [], DictList.empty )
-                        |> (\( json, expected ) ->
-                                ( "[" ++ String.join ", " json ++ "]"
-                                , expected
-                                )
-                           )
+                list
+                    |> List.foldr go ( [], DictList.empty )
+                    |> (\( json, expected ) ->
+                            ( "[" ++ String.join ", " json ++ "]"
+                            , expected
+                            )
+                       )
             )
 
 
@@ -186,20 +186,20 @@ jsonKeysObjectAndExpectedResult =
                             , DictList.cons (toString key) value expected
                             )
                 in
-                    list
-                        |> List.foldr go ( [], [], DictList.empty )
-                        |> (\( jsonKeys, jsonDict, expected ) ->
-                                let
-                                    keys =
-                                        "\"keys\": [" ++ String.join ", " jsonKeys ++ "]"
+                list
+                    |> List.foldr go ( [], [], DictList.empty )
+                    |> (\( jsonKeys, jsonDict, expected ) ->
+                            let
+                                keys =
+                                    "\"keys\": [" ++ String.join ", " jsonKeys ++ "]"
 
-                                    dict =
-                                        "\"dict\": {" ++ String.join ", " jsonDict ++ "}"
-                                in
-                                    ( "{" ++ keys ++ ", " ++ dict ++ "}"
-                                    , expected
-                                    )
-                           )
+                                dict =
+                                    "\"dict\": {" ++ String.join ", " jsonDict ++ "}"
+                            in
+                            ( "{" ++ keys ++ ", " ++ dict ++ "}"
+                            , expected
+                            )
+                       )
             )
 
 
@@ -231,9 +231,9 @@ jsonTests =
                     valueDecoder key =
                         JD.at [ "dict", key ] JD.int
                 in
-                    json
-                        |> JD.decodeString (DictList.decodeKeysAndValues keyDecoder valueDecoder)
-                        |> Expect.equal (Ok expected)
+                json
+                    |> JD.decodeString (DictList.decodeKeysAndValues keyDecoder valueDecoder)
+                    |> Expect.equal (Ok expected)
         ]
 
 
@@ -255,11 +255,11 @@ consTest =
                     DictList.head result
                         |> Expect.equal (Just ( key, value ))
             in
-                DictList.cons key value dictList
-                    |> Expect.all
-                        [ expectedSize
-                        , expectedHead
-                        ]
+            DictList.cons key value dictList
+                |> Expect.all
+                    [ expectedSize
+                    , expectedHead
+                    ]
 
 
 headTailConsTest : Test
@@ -278,7 +278,7 @@ headTailConsTest =
                     else
                         Just subject
             in
-                Expect.equal expected run
+            Expect.equal expected run
 
 
 indexedMapTest : Test
@@ -311,13 +311,13 @@ indexedMapTest =
                         |> List.map .value
                         |> Expect.equal (DictList.values subject)
             in
-                DictList.indexedMap go subject
-                    |> DictList.values
-                    |> Expect.all
-                        [ expectIndexes
-                        , expectKeys
-                        , expectValues
-                        ]
+            DictList.indexedMap go subject
+                |> DictList.values
+                |> Expect.all
+                    [ expectIndexes
+                    , expectKeys
+                    , expectValues
+                    ]
 
 
 filterMapTest : Test
@@ -545,10 +545,10 @@ sortByTest =
                     subject
                         |> DictList.map (\_ value -> { value = value })
             in
-                withRecord
-                    |> DictList.sortBy .value
-                    |> DictList.toList
-                    |> Expect.equal (DictList.toList withRecord |> List.sortBy (Tuple.second >> .value))
+            withRecord
+                |> DictList.sortBy .value
+                |> DictList.toList
+                |> Expect.equal (DictList.toList withRecord |> List.sortBy (Tuple.second >> .value))
 
 
 sortWithTest : Test
@@ -567,10 +567,10 @@ sortWithTest =
                         GT ->
                             LT
             in
-                subject
-                    |> DictList.sortWith reverseOrder
-                    |> DictList.toList
-                    |> Expect.equal (DictList.toList subject |> List.sortWith (\( _, a ) ( _, b ) -> reverseOrder a b))
+            subject
+                |> DictList.sortWith reverseOrder
+                |> DictList.toList
+                |> Expect.equal (DictList.toList subject |> List.sortWith (\( _, a ) ( _, b ) -> reverseOrder a b))
 
 
 


### PR DESCRIPTION
Some tests in an attempt to reproduce #16.

I haven't actually reproduced the problem in #16 yet, but have found a related problem, described below.