### PR TITLE
Fix various issues in managing the list

### DIFF
--- a/src/AllDictList.elm
+++ b/src/AllDictList.elm
@@ -910,24 +910,10 @@ insert key value (AllDictList dict list) =
 no changes are made.
 -}
 remove : k -> AllDictList k v comparable -> AllDictList k v comparable
-remove key ((AllDictList dict list) as dictList) =
-    if AllDict.member key dict then
-        -- Lists are not particularly optimized for removals ...
-        -- if that becomes a practical issue, we could perhaps
-        -- use an `Array` instead.
-        let
-            ord =
-                AllDict.getOrd dict
-
-            keyComparable =
-                ord key
-        in
-            AllDictList
-                (AllDict.remove key dict)
-                (List.filter (\k -> ord k /= keyComparable) list)
-    else
-        -- We avoid the list removal efficiently in this branch.
-        dictList
+remove key (AllDictList dict list) =
+    AllDictList
+        (AllDict.remove key dict)
+        (removeKey key dict list)
 
 
 {-| Update the value for a specific key with a given function. Maintains

--- a/src/AllDictList.elm
+++ b/src/AllDictList.elm
@@ -315,16 +315,9 @@ it already exists.
 -}
 cons : k -> v -> AllDictList k v comparable -> AllDictList k v comparable
 cons key value (AllDictList dict list) =
-    let
-        restOfList =
-            if AllDict.member key dict then
-                List.Extra.remove key list
-            else
-                list
-    in
-        AllDictList
-            (AllDict.insert key value dict)
-            (key :: restOfList)
+    AllDictList
+        (AllDict.insert key value dict)
+        (key :: removeKey key dict list)
 
 
 {-| Gets the first key with its value.
@@ -1295,3 +1288,21 @@ unsafeGet key dict =
 emptyWithOrdFrom : AllDictList k v1 comparable -> AllDictList k v2 comparable
 emptyWithOrdFrom =
     empty << getOrd
+
+
+{-| Removes a key from the list part, and returns the list.
+-}
+removeKey : k -> AllDict k v comparable -> List k -> List k
+removeKey key dict list =
+    let
+        ord =
+            AllDict.getOrd dict
+
+        keyComparable =
+            ord key
+    in
+        if AllDict.member key dict then
+            List.filter (\k -> ord k /= keyComparable) list
+        else
+            -- If the key wasn't present, we can skip the removal
+            list

--- a/src/AllDictList.elm
+++ b/src/AllDictList.elm
@@ -671,28 +671,24 @@ insertAfter afterKey key value (AllDictList dict list) =
             AllDict.insert key value dict
 
         newList =
-            if afterKey == key then
-                -- If we want to insert it after itself, we can short-circuit
-                list
-            else
-                let
-                    listWithoutKey =
-                        if AllDict.member key dict then
-                            List.Extra.remove key list
-                        else
-                            -- If the key wasn't present, we can skip the removal
-                            list
-                in
-                    case List.Extra.elemIndex afterKey listWithoutKey of
-                        Just index ->
-                            -- We found the existing element, so take apart the list
-                            -- and put it back together
-                            List.take (index + 1) listWithoutKey
-                                ++ (key :: List.drop (index + 1) listWithoutKey)
+            let
+                listWithoutKey =
+                    if AllDict.member key dict then
+                        List.Extra.remove key list
+                    else
+                        -- If the key wasn't present, we can skip the removal
+                        list
+            in
+                case List.Extra.elemIndex afterKey listWithoutKey of
+                    Just index ->
+                        -- We found the existing element, so take apart the list
+                        -- and put it back together
+                        List.take (index + 1) listWithoutKey
+                            ++ (key :: List.drop (index + 1) listWithoutKey)
 
-                        Nothing ->
-                            -- The afterKey wasn't found, so we insert the key at the end
-                            listWithoutKey ++ [ key ]
+                    Nothing ->
+                        -- The afterKey wasn't found, so we insert the key at the end
+                        listWithoutKey ++ [ key ]
     in
         AllDictList newDict newList
 
@@ -710,28 +706,24 @@ insertBefore beforeKey key value (AllDictList dict list) =
             AllDict.insert key value dict
 
         newList =
-            if beforeKey == key then
-                -- If we want to insert it before itself, we can short-circuit
-                list
-            else
-                let
-                    listWithoutKey =
-                        if AllDict.member key dict then
-                            List.Extra.remove key list
-                        else
-                            -- If the key wasn't present, we can skip the removal
-                            list
-                in
-                    case List.Extra.elemIndex beforeKey listWithoutKey of
-                        Just index ->
-                            -- We found the existing element, so take apart the list
-                            -- and put it back together
-                            List.take index listWithoutKey
-                                ++ (key :: List.drop index listWithoutKey)
+            let
+                listWithoutKey =
+                    if AllDict.member key dict then
+                        List.Extra.remove key list
+                    else
+                        -- If the key wasn't present, we can skip the removal
+                        list
+            in
+                case List.Extra.elemIndex beforeKey listWithoutKey of
+                    Just index ->
+                        -- We found the existing element, so take apart the list
+                        -- and put it back together
+                        List.take index listWithoutKey
+                            ++ (key :: List.drop index listWithoutKey)
 
-                        Nothing ->
-                            -- The beforeKey wasn't found, so we insert the key at the beginning
-                            key :: listWithoutKey
+                    Nothing ->
+                        -- The beforeKey wasn't found, so we insert the key at the beginning
+                        key :: listWithoutKey
     in
         AllDictList newDict newList
 

--- a/src/AllDictList.elm
+++ b/src/AllDictList.elm
@@ -543,37 +543,31 @@ drop n (AllDictList dict list) =
 {-| Sort values from lowest to highest
 -}
 sort : AllDictList k comparable1 comparable2 -> AllDictList k comparable1 comparable2
-sort dictList =
-    case dictList of
-        AllDictList dict list ->
-            toList dictList
-                |> List.sortBy second
-                |> List.map first
-                |> AllDictList dict
+sort ((AllDictList dict _) as dictList) =
+    toList dictList
+        |> List.sortBy second
+        |> List.map first
+        |> AllDictList dict
 
 
 {-| Sort values by a derived property.
 -}
 sortBy : (v -> comparable1) -> AllDictList k v comparable2 -> AllDictList k v comparable2
-sortBy func dictList =
-    case dictList of
-        AllDictList dict list ->
-            toList dictList
-                |> List.sortBy (func << second)
-                |> List.map first
-                |> AllDictList dict
+sortBy func ((AllDictList dict _) as dictList) =
+    toList dictList
+        |> List.sortBy (func << second)
+        |> List.map first
+        |> AllDictList dict
 
 
 {-| Sort values with a custom comparison function.
 -}
 sortWith : (v -> v -> Order) -> AllDictList k v comparable -> AllDictList k v comparable
-sortWith func dictList =
-    case dictList of
-        AllDictList dict list ->
-            toList dictList
-                |> List.sortWith (\v1 v2 -> func (second v1) (second v2))
-                |> List.map first
-                |> AllDictList dict
+sortWith func ((AllDictList dict _) as dictList) =
+    toList dictList
+        |> List.sortWith (\v1 v2 -> func (second v1) (second v2))
+        |> List.map first
+        |> AllDictList dict
 
 
 

--- a/tests/DictListTests.elm
+++ b/tests/DictListTests.elm
@@ -1009,6 +1009,82 @@ insertBeforeTest =
         ]
 
 
+insertBeforeFuzzTest : Test
+insertBeforeFuzzTest =
+    fuzz4 Fuzz.int Fuzz.int Fuzz.int fuzzIntDictList "fuzz insertAfter" <|
+        \before key value dictList ->
+            let
+                resultSize =
+                    if DictList.member key dictList then
+                        DictList.size dictList
+                    else
+                        DictList.size dictList + 1
+
+                expectedSize result =
+                    DictList.size result
+                        |> Expect.equal resultSize
+
+                expectedDictSize result =
+                    DictList.values result
+                        |> List.length
+                        |> Expect.equal resultSize
+
+                expectedListSize result =
+                    DictList.keys result
+                        |> List.length
+                        |> Expect.equal resultSize
+
+                expectedMember result =
+                    DictList.member key result
+                        |> Expect.equal True
+            in
+            DictList.insertBefore before key value dictList
+                |> Expect.all
+                    [ expectedSize
+                    , expectedDictSize
+                    , expectedListSize
+                    , expectedMember
+                    ]
+
+
+insertAfterFuzzTest : Test
+insertAfterFuzzTest =
+    fuzz4 Fuzz.int Fuzz.int Fuzz.int fuzzIntDictList "fuzz insertBefore" <|
+        \after key value dictList ->
+            let
+                resultSize =
+                    if DictList.member key dictList then
+                        DictList.size dictList
+                    else
+                        DictList.size dictList + 1
+
+                expectedSize result =
+                    DictList.size result
+                        |> Expect.equal resultSize
+
+                expectedDictSize result =
+                    DictList.values result
+                        |> List.length
+                        |> Expect.equal resultSize
+
+                expectedListSize result =
+                    DictList.keys result
+                        |> List.length
+                        |> Expect.equal resultSize
+
+                expectedMember result =
+                    DictList.member key result
+                        |> Expect.equal True
+            in
+            DictList.insertAfter after key value dictList
+                |> Expect.all
+                    [ expectedSize
+                    , expectedDictSize
+                    , expectedListSize
+                    , expectedMember
+                    ]
+
+
 getTest : Test
 getTest =
     fuzz2 Fuzz.int fuzzIntDictList "get" <|

--- a/tests/DictListTests.elm
+++ b/tests/DictListTests.elm
@@ -5,6 +5,7 @@ things not necessarily tested by the `DictTests` or the `ListTests`.
 -}
 
 import Arithmetic exposing (isEven)
+import Date exposing (Date)
 import Dict
 import DictList exposing (DictList)
 import Expect
@@ -808,6 +809,19 @@ insertAfterTest =
         ]
 
 
+type alias Things =
+    DictList Int Thing
+
+
+type alias Thing =
+    { a : Int
+    , b : Int
+    , c : Float
+    , d : Int
+    , e : Date
+    }
+
+
 insertBeforeTest : Test
 insertBeforeTest =
     describe "insertBefore"
@@ -859,6 +873,55 @@ insertBeforeTest =
                             , pair3
                             ]
                         )
+
+        -- From https://github.com/Gizra/elm-dictlist/issues/16
+        , describe "with record value" <|
+            let
+                thing =
+                    Thing 0 0 0 0 (Date.fromTime 0)
+            in
+            [ test "when empty" <|
+                \_ ->
+                    DictList.insertBefore 0 2 thing DictList.empty
+                        |> Expect.all
+                            [ DictList.values >> List.length >> Expect.equal 1
+                            , DictList.keys >> Expect.equal [ 2 ]
+                            ]
+            , test "when inserting before existing key" <|
+                \_ ->
+                    DictList.cons 0 thing DictList.empty
+                        |> DictList.insertBefore 0 2 thing
+                        |> Expect.all
+                            [ DictList.values >> List.length >> Expect.equal 2
+                            , DictList.keys >> Expect.equal [ 2, 0 ]
+                            ]
+            , test "when inserting before non-existing key" <|
+                \_ ->
+                    DictList.cons 0 thing DictList.empty
+                        |> DictList.insertBefore 7 2 thing
+                        |> Expect.all
+                            [ DictList.values >> List.length >> Expect.equal 2
+                            , DictList.keys >> Expect.equal [ 2, 0 ]
+                            ]
+            , test "when replacing before existing key" <|
+                \_ ->
+                    DictList.cons 1 thing DictList.empty
+                        |> DictList.cons 0 thing
+                        |> DictList.insertBefore 0 1 thing
+                        |> Expect.all
+                            [ DictList.values >> List.length >> Expect.equal 2
+                            , DictList.keys >> Expect.equal [ 1, 0 ]
+                            ]
+            , test "when replacing before non-existing key" <|
+                \_ ->
+                    DictList.cons 1 thing DictList.empty
+                        |> DictList.cons 0 thing
+                        |> DictList.insertBefore 8 1 thing
+                        |> Expect.all
+                            [ DictList.values >> List.length >> Expect.equal 2
+                            , DictList.keys >> Expect.equal [ 1, 0 ]
+                            ]
+            ]
         ]
 
 

--- a/tests/DictListTests.elm
+++ b/tests/DictListTests.elm
@@ -243,14 +243,20 @@ consTest =
     fuzz3 Fuzz.int Fuzz.int fuzzIntDictList "cons" <|
         \key value dictList ->
             let
+                resultSize =
+                    if DictList.member key dictList then
+                        DictList.size dictList
+                    else
+                        DictList.size dictList + 1
+
                 expectedSize result =
                     DictList.size result
-                        |> Expect.equal
-                            (if DictList.member key dictList then
-                                DictList.size dictList
-                             else
-                                DictList.size dictList + 1
-                            )
+                        |> Expect.equal resultSize
+
+                expectedListSize result =
+                    DictList.keys result
+                        |> List.length
+                        |> Expect.equal resultSize
 
                 expectedHead result =
                     DictList.head result
@@ -259,6 +265,7 @@ consTest =
             DictList.cons key value dictList
                 |> Expect.all
                     [ expectedSize
+                    , expectedListSize
                     , expectedHead
                     ]
 

--- a/tests/DictListTests.elm
+++ b/tests/DictListTests.elm
@@ -1069,3 +1069,35 @@ removeTest =
                             ]
                         )
         ]
+
+
+removeFuzzTest : Test
+removeFuzzTest =
+    fuzz3 Fuzz.int Fuzz.int fuzzIntDictList "renove fuzz" <|
+        \key value dictList ->
+            let
+                resultSize =
+                    if DictList.member key dictList then
+                        DictList.size dictList - 1
+                    else
+                        DictList.size dictList
+
+                expectedSize result =
+                    DictList.size result
+                        |> Expect.equal resultSize
+
+                expectedListSize result =
+                    DictList.keys result
+                        |> List.length
+                        |> Expect.equal resultSize
+
+                expectedMember result =
+                    DictList.member key result
+                        |> Expect.equal False
+            in
+            DictList.remove key dictList
+                |> Expect.all
+                    [ expectedSize
+                    , expectedListSize
+                    , expectedMember
+                    ]

--- a/tests/DictListTests.elm
+++ b/tests/DictListTests.elm
@@ -55,13 +55,13 @@ jsonObjectAndExpectedResult =
                             , DictList.cons (toString key) value expected
                             )
                 in
-                    list
-                        |> List.foldr go ( [], DictList.empty )
-                        |> (\( json, expected ) ->
-                                ( "{" ++ String.join ", " json ++ "}"
-                                , expected
-                                )
-                           )
+                list
+                    |> List.foldr go ( [], DictList.empty )
+                    |> (\( json, expected ) ->
+                            ( "{" ++ String.join ", " json ++ "}"
+                            , expected
+                            )
+                       )
             )
 
 
@@ -82,13 +82,13 @@ jsonArrayAndExpectedResult =
                             , DictList.cons key (ValueWithId key value) expected
                             )
                 in
-                    list
-                        |> List.foldr go ( [], DictList.empty )
-                        |> (\( json, expected ) ->
-                                ( "[" ++ String.join ", " json ++ "]"
-                                , expected
-                                )
-                           )
+                list
+                    |> List.foldr go ( [], DictList.empty )
+                    |> (\( json, expected ) ->
+                            ( "[" ++ String.join ", " json ++ "]"
+                            , expected
+                            )
+                       )
             )
 
 
@@ -134,13 +134,13 @@ jsonArray2AndExpectedResult =
                             , DictList.cons key (ValueWithoutId value) expected
                             )
                 in
-                    list
-                        |> List.foldr go ( [], DictList.empty )
-                        |> (\( json, expected ) ->
-                                ( "[" ++ String.join ", " json ++ "]"
-                                , expected
-                                )
-                           )
+                list
+                    |> List.foldr go ( [], DictList.empty )
+                    |> (\( json, expected ) ->
+                            ( "[" ++ String.join ", " json ++ "]"
+                            , expected
+                            )
+                       )
             )
 
 
@@ -186,20 +186,20 @@ jsonKeysObjectAndExpectedResult =
                             , DictList.cons (toString key) value expected
                             )
                 in
-                    list
-                        |> List.foldr go ( [], [], DictList.empty )
-                        |> (\( jsonKeys, jsonDict, expected ) ->
-                                let
-                                    keys =
-                                        "\"keys\": [" ++ String.join ", " jsonKeys ++ "]"
+                list
+                    |> List.foldr go ( [], [], DictList.empty )
+                    |> (\( jsonKeys, jsonDict, expected ) ->
+                            let
+                                keys =
+                                    "\"keys\": [" ++ String.join ", " jsonKeys ++ "]"
 
-                                    dict =
-                                        "\"dict\": {" ++ String.join ", " jsonDict ++ "}"
-                                in
-                                    ( "{" ++ keys ++ ", " ++ dict ++ "}"
-                                    , expected
-                                    )
-                           )
+                                dict =
+                                    "\"dict\": {" ++ String.join ", " jsonDict ++ "}"
+                            in
+                            ( "{" ++ keys ++ ", " ++ dict ++ "}"
+                            , expected
+                            )
+                       )
             )
 
 
@@ -231,9 +231,9 @@ jsonTests =
                     valueDecoder key =
                         JD.at [ "dict", key ] JD.int
                 in
-                    json
-                        |> JD.decodeString (DictList.decodeKeysAndValues keyDecoder valueDecoder)
-                        |> Expect.equal (Ok expected)
+                json
+                    |> JD.decodeString (DictList.decodeKeysAndValues keyDecoder valueDecoder)
+                    |> Expect.equal (Ok expected)
         ]
 
 
@@ -255,11 +255,11 @@ consTest =
                     DictList.head result
                         |> Expect.equal (Just ( key, value ))
             in
-                DictList.cons key value dictList
-                    |> Expect.all
-                        [ expectedSize
-                        , expectedHead
-                        ]
+            DictList.cons key value dictList
+                |> Expect.all
+                    [ expectedSize
+                    , expectedHead
+                    ]
 
 
 headTailConsTest : Test
@@ -278,7 +278,7 @@ headTailConsTest =
                     else
                         Just subject
             in
-                Expect.equal expected run
+            Expect.equal expected run
 
 
 indexedMapTest : Test
@@ -311,13 +311,13 @@ indexedMapTest =
                         |> List.map .value
                         |> Expect.equal (DictList.values subject)
             in
-                DictList.indexedMap go subject
-                    |> DictList.values
-                    |> Expect.all
-                        [ expectIndexes
-                        , expectKeys
-                        , expectValues
-                        ]
+            DictList.indexedMap go subject
+                |> DictList.values
+                |> Expect.all
+                    [ expectIndexes
+                    , expectKeys
+                    , expectValues
+                    ]
 
 
 filterMapTest : Test
@@ -545,10 +545,10 @@ sortByTest =
                     subject
                         |> DictList.map (\_ value -> { value = value })
             in
-                withRecord
-                    |> DictList.sortBy .value
-                    |> DictList.toList
-                    |> Expect.equal (DictList.toList withRecord |> List.sortBy (Tuple.second >> .value))
+            withRecord
+                |> DictList.sortBy .value
+                |> DictList.toList
+                |> Expect.equal (DictList.toList withRecord |> List.sortBy (Tuple.second >> .value))
 
 
 sortWithTest : Test
@@ -567,10 +567,10 @@ sortWithTest =
                         GT ->
                             LT
             in
-                subject
-                    |> DictList.sortWith reverseOrder
-                    |> DictList.toList
-                    |> Expect.equal (DictList.toList subject |> List.sortWith (\( _, a ) ( _, b ) -> reverseOrder a b))
+            subject
+                |> DictList.sortWith reverseOrder
+                |> DictList.toList
+                |> Expect.equal (DictList.toList subject |> List.sortWith (\( _, a ) ( _, b ) -> reverseOrder a b))
 
 
 

--- a/tests/DictListTests.elm
+++ b/tests/DictListTests.elm
@@ -813,6 +813,69 @@ insertAfterTest =
                             , ( 17, 117 )
                             ]
                         )
+
+        -- From https://github.com/Gizra/elm-dictlist/issues/16
+        , describe "with record value" <|
+            let
+                thing =
+                    Thing 0 0 0 0 (Date.fromTime 0)
+            in
+            [ test "when empty" <|
+                \_ ->
+                    DictList.insertAfter 0 2 thing DictList.empty
+                        |> Expect.all
+                            [ DictList.values >> List.length >> Expect.equal 1
+                            , DictList.toDict >> Dict.size >> Expect.equal 1
+                            , DictList.keys >> Expect.equal [ 2 ]
+                            ]
+            , test "when inserting after existing key" <|
+                \_ ->
+                    DictList.cons 0 thing DictList.empty
+                        |> DictList.insertAfter 0 2 thing
+                        |> Expect.all
+                            [ DictList.values >> List.length >> Expect.equal 2
+                            , DictList.toDict >> Dict.size >> Expect.equal 2
+                            , DictList.keys >> Expect.equal [ 0, 2 ]
+                            ]
+            , test "when inserting after non-existing key" <|
+                \_ ->
+                    DictList.cons 0 thing DictList.empty
+                        |> DictList.insertAfter 7 2 thing
+                        |> Expect.all
+                            [ DictList.values >> List.length >> Expect.equal 2
+                            , DictList.toDict >> Dict.size >> Expect.equal 2
+                            , DictList.keys >> Expect.equal [ 0, 2 ]
+                            ]
+            , test "when inserting after same non-existing key" <|
+                \_ ->
+                    DictList.cons 0 thing DictList.empty
+                        |> DictList.insertAfter 7 7 thing
+                        |> Expect.all
+                            [ DictList.values >> List.length >> Expect.equal 2
+                            , DictList.toDict >> Dict.size >> Expect.equal 2
+                            , DictList.keys >> Expect.equal [ 0, 7 ]
+                            ]
+            , test "when replacing after existing key" <|
+                \_ ->
+                    DictList.cons 1 thing DictList.empty
+                        |> DictList.cons 0 thing
+                        |> DictList.insertAfter 0 1 thing
+                        |> Expect.all
+                            [ DictList.values >> List.length >> Expect.equal 2
+                            , DictList.toDict >> Dict.size >> Expect.equal 2
+                            , DictList.keys >> Expect.equal [ 0, 1 ]
+                            ]
+            , test "when replacing after non-existing key" <|
+                \_ ->
+                    DictList.cons 1 thing DictList.empty
+                        |> DictList.cons 0 thing
+                        |> DictList.insertAfter 8 1 thing
+                        |> Expect.all
+                            [ DictList.values >> List.length >> Expect.equal 2
+                            , DictList.toDict >> Dict.size >> Expect.equal 2
+                            , DictList.keys >> Expect.equal [ 0, 1 ]
+                            ]
+            ]
         ]
 
 
@@ -912,6 +975,15 @@ insertBeforeTest =
                             [ DictList.values >> List.length >> Expect.equal 2
                             , DictList.toDict >> Dict.size >> Expect.equal 2
                             , DictList.keys >> Expect.equal [ 2, 0 ]
+                            ]
+            , test "when inserting before same non-existing key" <|
+                \_ ->
+                    DictList.cons 0 thing DictList.empty
+                        |> DictList.insertBefore 7 7 thing
+                        |> Expect.all
+                            [ DictList.values >> List.length >> Expect.equal 2
+                            , DictList.toDict >> Dict.size >> Expect.equal 2
+                            , DictList.keys >> Expect.equal [ 7, 0 ]
                             ]
             , test "when replacing before existing key" <|
                 \_ ->

--- a/tests/DictListTests.elm
+++ b/tests/DictListTests.elm
@@ -882,7 +882,7 @@ insertBeforeTest =
             in
             [ test "when empty" <|
                 \_ ->
-                    DictList.insertBefore 0 2 thing DictList.empty
+                    DictList.insertBefore 2 2 thing DictList.empty
                         |> Expect.all
                             [ DictList.values >> List.length >> Expect.equal 1
                             , DictList.keys >> Expect.equal [ 2 ]


### PR DESCRIPTION
This fixes the problem originally reported in #16.

At first, I couldn't reproduce #16, but then realized that it would occur if:

- the new key was equal to the key being inserted before or after; and
- the new key hadn't been used (i.e. it was really new)

So, this fixes that, as well as some related issues relating to the management of the list.